### PR TITLE
Fix car status command sync

### DIFF
--- a/app/src/main/java/li/power/app/wearos/teslakeywearble/MainActivity.java
+++ b/app/src/main/java/li/power/app/wearos/teslakeywearble/MainActivity.java
@@ -74,6 +74,11 @@ public class MainActivity extends Activity implements CarPagerAdapter.OnCarActio
     private LinearLayout pageIndicator;
     private CarPagerAdapter adapter;
     private List<Car> cars;
+
+    // Track last status to reduce redundant UI refreshes
+    private String lastConnectionStatusText = "";
+    private Boolean lastConnected = null;
+    private Boolean lastLocked = null;
     
     // BLE Service
     private BLEService bleService;
@@ -934,13 +939,22 @@ public class MainActivity extends Activity implements CarPagerAdapter.OnCarActio
             Log.d(TAG, "Activity已銷毀，跳過車輛狀態更新");
             return;
         }
-        
+
         if (currentVehicleIndex < cars.size()) {
+            // Skip if status didn't change
+            if (lastConnected != null && lastLocked != null &&
+                    lastConnected == connected && lastLocked == locked) {
+                return;
+            }
+
+            lastConnected = connected;
+            lastLocked = locked;
+
             Car currentCar = cars.get(currentVehicleIndex);
             currentCar.setConnected(connected);
             currentCar.setLocked(locked);
             // 注意：這裡不重置備箱狀態，讓備箱狀態由車輛狀態回調單獨處理
-            
+
             runOnUiThread(() -> {
                 try {
                     if (adapter != null) {
@@ -962,7 +976,14 @@ public class MainActivity extends Activity implements CarPagerAdapter.OnCarActio
             Log.d(TAG, "Activity已銷毀，跳過狀態更新");
             return;
         }
-        
+
+        // Skip if no change
+        if (statusText.equals(lastConnectionStatusText)) {
+            return;
+        }
+
+        lastConnectionStatusText = statusText;
+
         runOnUiThread(() -> {
             try {
                 if (adapter != null) {

--- a/app/src/main/java/li/power/app/wearos/teslakeywearble/adapters/CarPagerAdapter.java
+++ b/app/src/main/java/li/power/app/wearos/teslakeywearble/adapters/CarPagerAdapter.java
@@ -41,6 +41,10 @@ public class CarPagerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         this.context = context;
         this.cars = cars;
         this.listener = listener;
+
+        // Enable stable IDs to avoid unnecessary view recreation which may cause
+        // flickering when notifyItemChanged is called frequently
+        setHasStableIds(true);
     }
     
     /**
@@ -88,6 +92,16 @@ public class CarPagerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     @Override
     public int getItemCount() {
         return cars.size() + 1; // +1 for add car page
+    }
+
+    @Override
+    public long getItemId(int position) {
+        if (position < cars.size()) {
+            return cars.get(position).getId();
+        } else {
+            // Use a negative ID for the "add car" page
+            return -1;
+        }
     }
     
     class CarViewHolder extends RecyclerView.ViewHolder {
@@ -235,8 +249,10 @@ public class CarPagerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         longPressExecuted = false;
                         
                         // 立即顯示長按開始提示
+                        int pos = getBindingAdapterPosition();
+                        Car currentCar = (pos != RecyclerView.NO_POSITION) ? cars.get(pos) : car;
                         if (listener instanceof li.power.app.wearos.teslakeywearble.MainActivity) {
-                            ((li.power.app.wearos.teslakeywearble.MainActivity) listener).onFrontTrunkLongPressStarted(car);
+                            ((li.power.app.wearos.teslakeywearble.MainActivity) listener).onFrontTrunkLongPressStarted(currentCar);
                         }
                         
                         // 設置長按完成的回調
@@ -244,8 +260,10 @@ public class CarPagerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                             if (isLongPressing && !longPressExecuted) {
                                 longPressExecuted = true;
                                 // 執行長按操作
+                                int pos = getBindingAdapterPosition();
+                                Car currentCar = (pos != RecyclerView.NO_POSITION) ? cars.get(pos) : car;
                                 if (listener instanceof li.power.app.wearos.teslakeywearble.MainActivity) {
-                                    ((li.power.app.wearos.teslakeywearble.MainActivity) listener).onFrontTrunkLongPress(car);
+                                    ((li.power.app.wearos.teslakeywearble.MainActivity) listener).onFrontTrunkLongPress(currentCar);
                                 }
                             }
                         };
@@ -262,7 +280,9 @@ public class CarPagerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                             if (!longPressExecuted) {
                                 // 長按未完成，顯示短按提示
                                 if (listener != null) {
-                                    listener.onFrontTrunkClick(car);
+                                    int pos = getBindingAdapterPosition();
+                                    Car currentCar = (pos != RecyclerView.NO_POSITION) ? cars.get(pos) : car;
+                                    listener.onFrontTrunkClick(currentCar);
                                 }
                             }
                             
@@ -274,11 +294,19 @@ public class CarPagerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             });
             
             btnLockUnlock.setOnClickListener(v -> {
-                if (listener != null) listener.onLockUnlockClick(car);
+                if (listener != null) {
+                    int pos = getBindingAdapterPosition();
+                    Car currentCar = (pos != RecyclerView.NO_POSITION) ? cars.get(pos) : car;
+                    listener.onLockUnlockClick(currentCar);
+                }
             });
             
             btnRearTrunk.setOnClickListener(v -> {
-                if (listener != null) listener.onRearTrunkClick(car);
+                if (listener != null) {
+                    int pos = getBindingAdapterPosition();
+                    Car currentCar = (pos != RecyclerView.NO_POSITION) ? cars.get(pos) : car;
+                    listener.onRearTrunkClick(currentCar);
+                }
             });
         }
     }

--- a/app/src/main/java/li/power/app/wearos/teslakeywearble/services/BLEService.java
+++ b/app/src/main/java/li/power/app/wearos/teslakeywearble/services/BLEService.java
@@ -1311,7 +1311,7 @@ public class BLEService extends Service {
     /**
      * Get Session
      */
-    private SessionManager.Session getSession(String vehicleId, UniversalMessage.Domain domain) {
+    private synchronized SessionManager.Session getSession(String vehicleId, UniversalMessage.Domain domain) {
         Map<UniversalMessage.Domain, SessionManager.Session> sessions = vehicleSessions.get(vehicleId);
         return sessions != null ? sessions.get(domain) : null;
     }
@@ -1611,7 +1611,7 @@ public class BLEService extends Service {
     /**
      * Update connection status and notify
      */
-    private void updateConnectionStatus(String status) {
+    private synchronized void updateConnectionStatus(String status) {
         this.connectionStatus = status;
         Log.d(TAG, "Connection status changed: " + status + " (Vehicle: " + currentVehicleId + ")");
 


### PR DESCRIPTION
## Summary
- ensure car button handlers always use latest state by looking up item at click time
- synchronize session lookup and connection status updates in BLEService

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478bc65ef883248ae02621ca53c441